### PR TITLE
Fix German localization for Submit Evaluation button

### DIFF
--- a/languages/mobility-trailblazers-de_DE.po
+++ b/languages/mobility-trailblazers-de_DE.po
@@ -73,7 +73,7 @@ msgid "Save as Draft"
 msgstr "Als Entwurf speichern"
 
 msgid "Submit Evaluation"
-msgstr "Bewertung einreichen"
+msgstr "Bewertung abschließen"
 
 msgid "Evaluation Guidelines"
 msgstr "Bewertungsrichtlinien"


### PR DESCRIPTION
Changed 'Bewertung einreichen' to 'Bewertung abschließen' for better tone and context in the jury evaluation interface.

The new translation better reflects the finality of completing an evaluation rather than just submitting it, aligning with the platform's formal tone.

Fixes #28