### PR TITLE
Remove 'Draft' option from jury dashboard filter dropdown

### DIFF
--- a/templates/frontend/jury-dashboard.php
+++ b/templates/frontend/jury-dashboard.php
@@ -137,7 +137,6 @@ $layout_class = 'mt-candidates-' . (isset($dashboard_settings['card_layout']) ? 
             <select class="mt-filter-select" id="mt-status-filter">
                 <option value=""><?php _e('All Statuses', 'mobility-trailblazers'); ?></option>
                 <option value="pending"><?php _e('Pending', 'mobility-trailblazers'); ?></option>
-                <option value="draft"><?php _e('Draft', 'mobility-trailblazers'); ?></option>
                 <option value="completed"><?php _e('Completed', 'mobility-trailblazers'); ?></option>
             </select>
         </div>


### PR DESCRIPTION
- Removes the 'Draft' option from mt-filter-select in jury dashboard
- Affects both regular jury dashboard and Elementor widget (same template)
- English and German translations handled automatically
- Relates to removal of draft save functionality on evaluation page