### PR TITLE
Remove 'Draft' option from jury dashboard dropdown filter

### DIFF
--- a/templates/admin/evaluations.php
+++ b/templates/admin/evaluations.php
@@ -62,7 +62,6 @@ $candidates = get_posts([
             <div class="alignleft actions">
                 <select name="status" id="filter-status">
                     <option value=""><?php _e('All Statuses', 'mobility-trailblazers'); ?></option>
-                    <option value="draft" <?php selected($filter_status, 'draft'); ?>><?php _e('Draft', 'mobility-trailblazers'); ?></option>
                     <option value="completed" <?php selected($filter_status, 'completed'); ?>><?php _e('Completed', 'mobility-trailblazers'); ?></option>
                 </select>
                 

--- a/templates/frontend/jury-dashboard.php
+++ b/templates/frontend/jury-dashboard.php
@@ -137,7 +137,6 @@ $layout_class = 'mt-candidates-' . (isset($dashboard_settings['card_layout']) ? 
             <select class="mt-filter-select" id="mt-status-filter">
                 <option value=""><?php _e('All Statuses', 'mobility-trailblazers'); ?></option>
                 <option value="pending"><?php _e('Pending', 'mobility-trailblazers'); ?></option>
-                <option value="draft"><?php _e('Draft', 'mobility-trailblazers'); ?></option>
                 <option value="completed"><?php _e('Completed', 'mobility-trailblazers'); ?></option>
             </select>
         </div>


### PR DESCRIPTION
- Removes draft filter option from templates/frontend/jury-dashboard.php line 140
- This affects both the standalone jury dashboard and Elementor widget versions
- Aligns with the removal of draft save functionality from evaluation page
- JavaScript filtering continues to work correctly without draft option