### PR TITLE
chore: update version to 2.5.36

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mobility Trailblazers WordPress Plugin
 
-**Version:** 2.5.25  
+**Version:** 2.5.36
 **Author:** Nicolas Estrem  
 **License:** GPL v2 or later  
 **WordPress Version:** 5.8+  
@@ -217,7 +217,7 @@ Located in `../../Documentation/`:
 
 ## 📈 Platform Status
 
-**Current Version**: 2.5.25 (January 18, 2025)  
+**Current Version**: 2.5.36 (January 18, 2025)
 **Status**: Production Ready ✅
 
 ### Recent Updates
@@ -237,4 +237,4 @@ Located in `../../Documentation/`:
 
 **Developed for the Mobility Trailblazers initiative** - Recognizing pioneers in mobility transformation across the DACH region.
 
-*Last updated: January 18, 2025 | Version 2.5.25*
+*Last updated: January 18, 2025 | Version 2.5.36*


### PR DESCRIPTION
## Summary
- bump plugin version references to 2.5.36 in README

## Testing
- `npm test` *(fails: could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a514ba7d288326a8816abd4d3ff945