### PR TITLE
Fix jury dashboard evaluation status logic

### DIFF
--- a/includes/services/class-mt-evaluation-service.php
+++ b/includes/services/class-mt-evaluation-service.php
@@ -460,8 +460,11 @@ class MT_Evaluation_Service implements MT_Service_Interface {
                 
                 if ($eval->status === 'completed') {
                     $progress['completed']++;
-                } else {
+                } elseif ($eval->status === 'draft') {
                     $progress['drafts']++;
+                } else {
+                    // Handle any other statuses as pending
+                    $progress['pending']++;
                 }
             } else {
                 $progress['pending']++;


### PR DESCRIPTION
Previously all non-completed evaluations were counted as drafts, causing incorrect 'Entwurf' (Draft) status display in the dashboard.

Now properly distinguishes between:
- completed: finished evaluations
- draft: actual draft saves
- pending: other statuses (treated as pending)

Fixes #50