### PR TITLE
fix: Update German text strings per issue #72

### DIFF
--- a/includes/emergency-german-fixes.php
+++ b/includes/emergency-german-fixes.php
@@ -87,10 +87,10 @@ add_filter('gettext', function($translated, $text, $domain) {
     $emergency_translations = [
         // Rankings page
         'Top Ranked Candidates' => 'Rangliste der bewerteten Kandidaten',
-        'Real-time ranking based on evaluation scores' => 'Echtzeit-Ranking basierend auf Bewertungsergebnissen',
+        'Real-time ranking based on evaluation scores' => 'Sie können die Werte direkt in der Rangliste ändern.',
         'Rank' => 'Rang',
         'Candidate' => 'Kandidat/in',
-        'Actions' => 'Aktionen',
+        'Actions' => 'Änderungen',
         'Full View' => 'Details anzeigen',
         'Average Score' => 'Durchschnittliche Bewertung',
         'Average Score:' => 'Durchschnittliche Bewertung:',

--- a/languages/mobility-trailblazers-de_DE.po
+++ b/languages/mobility-trailblazers-de_DE.po
@@ -933,7 +933,7 @@ msgid "Your Rankings"
 msgstr "Ihre Rangliste"
 
 msgid "Real-time ranking based on evaluation scores"
-msgstr "Echtzeit-Ranking basierend auf Bewertungsergebnissen"
+msgstr "Sie können die Werte direkt in der Rangliste ändern."
 
 msgid "Rank"
 msgstr "Rang"
@@ -942,7 +942,7 @@ msgid "Candidate"
 msgstr "Kandidat/in"
 
 msgid "Actions"
-msgstr "Aktionen"
+msgstr "Änderungen"
 
 msgid "Full View"
 msgstr "Details anzeigen"


### PR DESCRIPTION
Updates German UI text as requested in issue #72

- Replace 'Aktionen' with 'Änderungen' in mt-evaluation-table
- Replace 'Echtzeit-Ranking basierend auf Bewertungsergebnissen' with 'Sie können die Werte direkt in der Rangliste ändern.' in mt-rankings-subtitle

Updated both emergency-german-fixes.php and translation file for immediate effect.

Generated with [Claude Code](https://claude.ai/code)